### PR TITLE
[FIZZ-81] Soft deletes

### DIFF
--- a/docs/sample-out/users/2020-09-17-15-04-23.csv
+++ b/docs/sample-out/users/2020-09-17-15-04-23.csv
@@ -10,4 +10,4 @@
 100032898,Schoology,teacher,kelley.christian,207270,Kelley Heidi Christian,Kelley.Christian@studentgps.org,Active,2020-08-20 12:34:50,2020-08-20 12:34:50
 100032899,Schoology,teacher,sara.preston,207268,Sara Stacy Preston,Sara.Preston@studentgps.org,Archived,2020-08-20 12:34:50,2020-08-20 12:34:50
 100032900,Schoology,teacher,sara.preston.2,207268,Sara Stacy Preston,Sara.Preston@studentgps.org,Active,2020-08-20 12:34:50,2020-08-20 12:34:50
-1,Schoology,principal,delete.me,,,This person will be deleted from the next file,principal@studentgps.org,Archived,2020-10-01 00:00:01,2020-10-01 00:00:01
+1,Schoology,principal,delete.me,,This person will be deleted from the next file,principal@studentgps.org,Archived,2020-10-01 00:00:01,2020-10-01 00:00:01

--- a/docs/sample-out/users/2020-09-17-15-04-23.csv
+++ b/docs/sample-out/users/2020-09-17-15-04-23.csv
@@ -10,3 +10,4 @@
 100032898,Schoology,teacher,kelley.christian,207270,Kelley Heidi Christian,Kelley.Christian@studentgps.org,Active,2020-08-20 12:34:50,2020-08-20 12:34:50
 100032899,Schoology,teacher,sara.preston,207268,Sara Stacy Preston,Sara.Preston@studentgps.org,Archived,2020-08-20 12:34:50,2020-08-20 12:34:50
 100032900,Schoology,teacher,sara.preston.2,207268,Sara Stacy Preston,Sara.Preston@studentgps.org,Active,2020-08-20 12:34:50,2020-08-20 12:34:50
+1,Schoology,principal,delete.me,,,This person will be deleted from the next file,principal@studentgps.org,Archived,2020-10-01 00:00:01,2020-10-01 00:00:01

--- a/docs/sample-out/users/2020-09-18-15-05-01.csv
+++ b/docs/sample-out/users/2020-09-18-15-05-01.csv
@@ -1,3 +1,12 @@
 ﻿SourceSystemIdentifier,SourceSystem,UserRole,LocalUserIdentifier,SISUserIdentifier,Name,EmailAddress,EntityStatus,CreateDate,LastModifiedDate
 100032890,Schoology,student,mary.archer,604863,Mary Archer,Mary.Archer@studentgps.org,Archived,2020-08-20 12:34:50,2020-09-18 12:34:50
 100032891,Schoology,student,kyle.hughes,604874,Kyle Hughes,Kyle.Hughes@studentgps.org,Archived,2020-08-20 12:34:50,2020-09-18 12:34:50
+100032892,Schoology,student,peter.nash,604918,Peter Ivan Nash,Peter.Nash@studentgps.org,Active,2020-08-20 12:34:50,2020-08-20 12:34:50
+100032893,Schoology,student,larry.mahoney,604927,Larry Mahoney,Larry.Mahoney@studentgps.org,Active,2020-08-20 12:34:50,2020-08-20 12:34:50
+100032894,Schoology,student,roland.phillips,604938,Roland Phillips,Roland.Phillips@studentgps.org,Active,2020-08-20 12:34:50,2020-08-20 12:34:50
+100032895,Schoology,student,stephen.caldwell,604969,Stephen Caldwell,Stephen.Caldwell@studentgps.org,Active,2020-08-20 12:34:50,2020-08-20 12:34:50
+100032896,Schoology,student,olivia.hardy,604974,Olivia Doris Hardy,Olivia.Hardy@studentgps.org,Active,2020-08-20 12:34:50,2020-08-20 12:34:50
+100032897,Schoology,student,micheal.turner,605015,Micheal Turner,Micheal.Turner@studentgps.org,Active,2020-08-20 12:34:50,2020-08-20 12:34:50
+100032898,Schoology,teacher,kelley.christian,207270,Kelley Heidi Christian,Kelley.Christian@studentgps.org,Active,2020-08-20 12:34:50,2020-08-20 12:34:50
+100032899,Schoology,teacher,sara.preston,207268,Sara Stacy Preston,Sara.Preston@studentgps.org,Archived,2020-08-20 12:34:50,2020-08-20 12:34:50
+100032900,Schoology,teacher,sara.preston.2,207268,Sara Stacy Preston,Sara.Preston@studentgps.org,Active,2020-08-20 12:34:50,2020-08-20 12:34:50

--- a/src/lms-ds-installer/mssql/0001-table-user.sql
+++ b/src/lms-ds-installer/mssql/0001-table-user.sql
@@ -1,5 +1,5 @@
-CREATE TABLE lms.[User] (
-    Identifier INT NOT NULL IDENTITY,
+CREATE TABLE lms.LMSUser (
+    LMSUserIdentifier INT NOT NULL IDENTITY,
     SourceSystemIdentifier VARCHAR(50) NOT NULL,
     SourceSystem VARCHAR(50) NOT NULL,
     UserRole VARCHAR(50) NOT NULL,
@@ -12,7 +12,7 @@ CREATE TABLE lms.[User] (
     LastModifiedDate DATETIME2 NOT NULL CONSTRAINT DF_User_LastModifiedDate DEFAULT (getdate()),
     DeletedAt DATETIME2,
     CONSTRAINT PK_User PRIMARY KEY CLUSTERED (
-        Identifier ASC
+        LMSUserIdentifier ASC
     ) WITH(
         PAD_INDEX = OFF,
         STATISTICS_NORECOMPUTE = OFF,
@@ -26,7 +26,7 @@ CREATE TABLE lms.[User] (
     )
 ) ON [PRIMARY];
 
-CREATE TABLE lms.[stg_User] (
+CREATE TABLE lms.stg_LMSUser (
     StagingId INT NOT NULL IDENTITY,
     SourceSystemIdentifier VARCHAR(50) NOT NULL,
     SourceSystem VARCHAR(50) NOT NULL,
@@ -49,5 +49,5 @@ CREATE TABLE lms.[stg_User] (
     ) ON [PRIMARY],
 ) ON [PRIMARY];
 
-CREATE INDEX IX_stg_User_Natural_Key ON lms.[stg_user] (SourceSystemIdentifier, SourceSystem, LastModifiedDate);
+CREATE INDEX IX_stg_User_Natural_Key ON lms.stg_LMSUser (SourceSystemIdentifier, SourceSystem, LastModifiedDate);
 

--- a/src/lms-ds-installer/mssql/0001-table-user.sql
+++ b/src/lms-ds-installer/mssql/0001-table-user.sql
@@ -49,5 +49,5 @@ CREATE TABLE lms.stg_LMSUser (
     ) ON [PRIMARY],
 ) ON [PRIMARY];
 
-CREATE INDEX IX_stg_User_Natural_Key ON lms.stg_LMSUser (SourceSystemIdentifier, SourceSystem, LastModifiedDate);
+CREATE INDEX IX_stg_LMSUser_Natural_Key ON lms.[stg_lmsuser] (SourceSystemIdentifier, SourceSystem, LastModifiedDate);
 

--- a/src/lms-ds-loader/README.md
+++ b/src/lms-ds-loader/README.md
@@ -19,7 +19,14 @@ Limitations as of September 23, 2020:
    poetry install
    ```
 
-1. Run the two SQL scripts in `src/lms-ds-installer/mssql` in a database.
+1. Run the two SQL scripts in `src/lms-ds-installer/mssql` in a SQL Server
+   database.
+1. The database account used when running the tool needs to be a member of the
+   following roles in the destination database:
+
+   * db_datareader
+   * db_datawriter
+   * db_ddladmin
 
 ## Running the Tool
 

--- a/src/lms-ds-loader/lms_ds_loader/argparser.py
+++ b/src/lms-ds-loader/lms_ds_loader/argparser.py
@@ -57,9 +57,12 @@ def parse_arguments(args_in) -> Arguments:
         "-p", "--password", required=user_name_required, env_var="MSSQL_PASSWORD"
     )
 
+    parser.add("-v", "--verbose", help="Enable verbose logging", action="store_true")
+
     args_parsed = parser.parse_args(args_in)
 
     arguments = Arguments(args_parsed.csvpath, args_parsed.engine)
+    arguments.verbose = args_parsed.verbose
 
     if args_parsed.useintegratedsecurity:
         arguments.set_connection_string_using_integrated_security(

--- a/src/lms-ds-loader/lms_ds_loader/arguments.py
+++ b/src/lms-ds-loader/lms_ds_loader/arguments.py
@@ -25,6 +25,9 @@ class Arguments:
     csv_path: str
     engine: str
 
+    def __post_init__(self):
+        self.verbose = False
+
     @staticmethod
     def _get_mssql_port(port):
         if not port:

--- a/src/lms-ds-loader/lms_ds_loader/constants.py
+++ b/src/lms-ds-loader/lms_ds_loader/constants.py
@@ -12,7 +12,7 @@ class Constants:
         POSTGRESQL = "postgresql"
 
     class Table:
-        USER = "User"
+        USER = "LMSUser"
 
     class Columns:
         USER = [

--- a/src/lms-ds-loader/lms_ds_loader/csv_to_sql.py
+++ b/src/lms-ds-loader/lms_ds_loader/csv_to_sql.py
@@ -57,5 +57,6 @@ class CsvToSql:
 
         adapter.insert_new_records_to_production(table, columns)
         adapter.copy_updates_to_production(table, columns)
+        adapter.soft_delete_from_production(table)
 
         adapter.enable_staging_natural_key_index(table)

--- a/src/lms-ds-loader/lms_ds_loader/main.py
+++ b/src/lms-ds-loader/lms_ds_loader/main.py
@@ -10,21 +10,48 @@ Model (LMS-UDM) into a Learning Management System Data Store (LMS-DS) database.
 call `python main.py -h` for a detailed listing of command arguments.
 """
 
+import logging
+import os
 import sys
+import time
 
 from lms_ds_loader.argparser import parse_arguments
 from lms_ds_loader.lms_filesystem_provider import LmsFilesystemProvider
 from lms_ds_loader.file_processor import FileProcessor
 
 
-def main():
-    arguments = parse_arguments(sys.argv[1:])
+def _configure_logging(verbose: bool):
+    default_level = "INFO"
+    if verbose:
+        default_level = "DEBUG"
+        logging.getLogger('sqlalchemy.engine').setLevel(logging.INFO)
 
+    logging.basicConfig(
+        handlers=[
+            logging.StreamHandler(sys.stdout),
+        ],
+        format="%(asctime)s - %(levelname)s - %(message)s",
+        level=os.environ.get("LOGLEVEL", default_level),
+    )
+
+
+def main():
+
+    tic = time.perf_counter()
+
+    arguments = parse_arguments(sys.argv[1:])
+    _configure_logging(arguments.verbose)
+
+    logging.info("Starting filesystem processing...")
     fs = LmsFilesystemProvider(arguments.csv_path)
     fs.get_all_files()
 
     processor = FileProcessor(fs, arguments.get_db_operations_adapter())
     processor.load_lms_files_into_database()
+
+    toc = time.perf_counter()
+
+    logging.debug(f"Processing time: {toc - tic:0.4f} seconds")
 
 
 if __name__ == "__main__":

--- a/src/lms-ds-loader/tests/test_argparser.py
+++ b/src/lms-ds-loader/tests/test_argparser.py
@@ -349,4 +349,21 @@ class Test_parse_arguments:
         # suite - test only enough here to prove the point
         assert self.PASSWORD in parsed.connection_string
 
+    def test_when_verbose_flag_provided_then_set_verbose_true(self, capsys):
+        args = [
+            *self.path_args(),
+            *self.server_args(),
+            *self.db_name_args(),
+            *self.integrated_security_arg(),
+            *self.engine_args(Constants.DbEngine.MSSQL),
+            "--verbose"
+        ]
+
+        parsed = parse_arguments(args)
+
+        self.assert_no_messages(capsys)
+
+        assert parsed is not None, "No arguments detected"
+        assert parsed.verbose, "verbose not set"
+
     # NOT TESTING POSTGRESQL UNTIL STORY REQUIRES POSTGRESQL

--- a/src/lms-ds-loader/tests/test_mssql_lms_operations.py
+++ b/src/lms-ds-loader/tests/test_mssql_lms_operations.py
@@ -251,3 +251,36 @@ and t.lastmodifieddate <> stg.lastmodifieddate
 
             # Assert
             exec_mock.assert_called_with(expected)
+
+    class Test_when_soft_deleting_a_record:
+        class Test_given_invalid_arguments:
+            def test_given_table_is_none_then_raise_error(self):
+                with pytest.raises(AssertionError):
+                    MssqlLmsOperations("a").soft_delete_from_production(None)
+
+            def test_given_table_is_whitespace_then_raise_error(self):
+                with pytest.raises(AssertionError):
+                    MssqlLmsOperations("a").soft_delete_from_production("   ")
+
+        class Test_given_valid_input:
+            def test_then_update_records_that_are_not_in_the_staging_table(self, mocker):
+
+                table = "tbl"
+                expected = """
+update t set t.deletedat = getdate()
+from lms.[tbl] as t
+where not exists (
+select 1 from lms.stg_tbl as stg
+where t.sourcesystemidentifier = stg.sourcesystemidentifier
+and t.sourcesystem = stg.sourcesystem
+) and deletedat is null"""
+                expected = expected.strip()
+
+                # Arrange
+                exec_mock = mocker.patch.object(MssqlLmsOperations, "_exec")
+
+                # Act
+                MssqlLmsOperations("aaa").soft_delete_from_production(table)
+
+                # Assert
+                exec_mock.assert_called_with(expected)


### PR DESCRIPTION
Adds support for soft deletes. 

I also added a little bit of logging to help me debug a problem: I discovered that SqlAlchemy opens transactions automatically and normally commits them right away, but for truncate it was not committing. Thus the truncate command was being rolled back. I suspect it is because truncate does not return a row count. The new verbose mode allowed me to print the SQL statements, including `COMMIT`. Solution: change to explicit session management.

There is more work to do in improving the logging, for example listing the name of the file being processed. I've left this for the dedicated logging ticket.