### PR TITLE
[FIZZ-57] Build automation for Canvas Extractor

### DIFF
--- a/.github/ubuntu-20.04-local.dockerfile
+++ b/.github/ubuntu-20.04-local.dockerfile
@@ -1,0 +1,24 @@
+# use this Dockerfile to create a local Ubuntu 20.04 image that is
+# suitable for use with https://github.com/nektos/act, as suggested
+# in https://github.com/nektos/act/issues/418#issuecomment-727261137
+#
+# Build:
+# docker build -f ubuntu-20.04-local.dockerfile -t ubuntu-builder .
+#
+# Use:
+# act -P ubuntu-20.04=ubuntu-builder
+#
+
+FROM ubuntu:20.04
+
+RUN apt-get update \
+    && apt-get upgrade -y \
+    && DEBIAN_FRONTEND=noninteractive apt-get install -y \
+    build-essential \
+    curl \
+    nodejs \
+    npm \
+    && rm -rf /var/lib/apt/lists/*
+
+
+# TODO: consider adding python files into /opt/hostedtoolcache/Python/3.7.9/x64

--- a/.github/workflows/file-tester.yml
+++ b/.github/workflows/file-tester.yml
@@ -1,4 +1,9 @@
-name: "File-Tester"
+# SPDX-License-Identifier: Apache-2.0
+# Licensed to the Ed-Fi Alliance under one or more agreements.
+# The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+# See the LICENSE and NOTICES files in the project root for more information.
+
+name: File Tester
 on:
   pull_request:
     paths:
@@ -9,7 +14,7 @@ on:
     paths:
       - 'utils/file-tester/**.py'
 jobs:
-  file-tester-tests:
+  test-file-tester:
     name: Run unit, style, and type checks
     runs-on: ubuntu-20.04
     steps:

--- a/.github/workflows/file-tester.yml
+++ b/.github/workflows/file-tester.yml
@@ -3,27 +3,32 @@ on:
   pull_request:
     paths:
       - 'utils/file-tester/**.py'
+  push:
+    branches:
+      - main
+    paths:
+      - 'utils/file-tester/**.py'
 jobs:
-  build-and-test:
-    name: Build and Test
+  file-tester-tests:
+    name: Run unit, style, and type checks
     runs-on: ubuntu-20.04
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f
 
       - name: Install Python 3.8
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@3105fb18c05ddd93efea5f9e0bef7a03a6e9e7df
         with:
           python-version: '3.8.x'
 
       - name: Install Poetry
-        uses: Gr1N/setup-poetry@v4
+        uses: Gr1N/setup-poetry@462ac83c852d49e282a1233c4c24c5411696e7c7
 
       - name: Install Python Dependencies
         run: python ./eng/build.py install ../utils/file-tester
 
       - name: Cache Dependencies
-        uses: actions/cache@v1
+        uses: actions/cache@0781355a23dac32fd3bac414512f4b903437991a
         with:
           path: ~/.cache/pypoetry/virtualenvs
           key: ${{ runner.os }}-poetry-${{ hashFiles('poetry.lock') }}

--- a/.github/workflows/file-tester.yml
+++ b/.github/workflows/file-tester.yml
@@ -1,0 +1,40 @@
+name: "File-Tester"
+on:
+  pull_request:
+    paths:
+      - 'utils/file-tester/**.py'
+jobs:
+  build-and-test:
+    name: Build and Test
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Install Python 3.8
+        uses: actions/setup-python@v2
+        with:
+          python-version: '3.8.x'
+
+      - name: Install Poetry
+        uses: Gr1N/setup-poetry@v4
+
+      - name: Install Python Dependencies
+        run: python ./eng/build.py install ../utils/file-tester
+
+      - name: Cache Dependencies
+        uses: actions/cache@v1
+        with:
+          path: ~/.cache/pypoetry/virtualenvs
+          key: ${{ runner.os }}-poetry-${{ hashFiles('poetry.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-poetry-
+
+      - name: Run Tests with Coverage
+        run: python ./eng/build.py coverage:html ../utils/file-tester
+
+      - name: Type Check
+        run: python ./eng/build.py typecheck:xml ../utils/file-tester
+
+      - name: Style Check
+        run: python ./eng/build.py lint ../utils/file-tester

--- a/.github/workflows/test-canvas.yml
+++ b/.github/workflows/test-canvas.yml
@@ -1,0 +1,56 @@
+# SPDX-License-Identifier: Apache-2.0
+# Licensed to the Ed-Fi Alliance under one or more agreements.
+# The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+# See the LICENSE and NOTICES files in the project root for more information.
+
+name: Canvas Extractor
+on:
+  pull_request:
+    paths:
+      - 'src/canvas/**.py'
+  push:
+    branches:
+      - main
+    paths:
+      - 'src/canvas/**.py'
+jobs:
+  test-canvas-extractor:
+    name: Run unit, style, and type checks
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f
+
+      - name: Install Python 3.8
+        # very carefully use the tag when testing with act-cli on localhost, commit the hash version
+        # uses: actions/setup-python@v2
+        uses: actions/setup-python@3105fb18c05ddd93efea5f9e0bef7a03a6e9e7df
+        with:
+          python-version: '3.8.x'
+
+      - name: Install Poetry
+        # very carefully use the tag when testing with act-cli on localhost, commit the hash version
+        # uses: Gr1N/setup-poetry@v4
+        uses: Gr1N/setup-poetry@462ac83c852d49e282a1233c4c24c5411696e7c7
+
+      - name: Install Python Dependencies
+        run: python ./eng/build.py install ../utils/file-tester
+
+      - name: Cache Dependencies
+        # very carefully use the tag when testing with act-cli on localhost, commit the hash version
+        # uses: actions/cache@v2
+        uses: actions/cache@0781355a23dac32fd3bac414512f4b903437991a
+        with:
+          path: ~/.cache/pypoetry/virtualenvs
+          key: ${{ runner.os }}-poetry-${{ hashFiles('poetry.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-poetry-
+
+      - name: Run Tests with Coverage
+        run: python ./eng/build.py coverage:html ../utils/file-tester
+
+      - name: Type Check
+        run: python ./eng/build.py typecheck:xml ../utils/file-tester
+
+      - name: Style Check
+        run: python ./eng/build.py lint ../utils/file-tester

--- a/.github/workflows/test-canvas.yml
+++ b/.github/workflows/test-canvas.yml
@@ -7,12 +7,12 @@ name: Canvas Extractor
 on:
   pull_request:
     paths:
-      - 'src/canvas/**.py'
+      - 'src/canvas-extractor/**.py'
   push:
     branches:
       - main
     paths:
-      - 'src/canvas/**.py'
+      - 'src/canvas-extractor/**.py'
 jobs:
   test-canvas-extractor:
     name: Run unit, style, and type checks

--- a/.gitignore
+++ b/.gitignore
@@ -148,3 +148,4 @@ cython_debug/
 
 # GitHub actions local CLI
 act/
+.actrc

--- a/.gitignore
+++ b/.gitignore
@@ -147,4 +147,4 @@ cython_debug/
 *.sqlite
 
 # GitHub actions local CLI
-./act/
+act/

--- a/.gitignore
+++ b/.gitignore
@@ -145,3 +145,6 @@ cython_debug/
 
 # Embedded databases
 *.sqlite
+
+# GitHub actions local CLI
+./act/

--- a/src/canvas-extractor/tests/test_extract_facade.py
+++ b/src/canvas-extractor/tests/test_extract_facade.py
@@ -27,7 +27,7 @@ from canvas_extractor.mapping import (
 )
 
 TEST_START_DATE = "2021-01-01"
-TEST_END_DATE = "2021-12-31"
+TEST_END_DATE = "2021-12-30"
 
 
 @pytest.fixture

--- a/utils/file-tester/tests/validators/test_directory_validation.py
+++ b/utils/file-tester/tests/validators/test_directory_validation.py
@@ -11,7 +11,7 @@ from lms_file_tester.validators import directory_validation as drval
 
 INPUT_DIR = "input_dir"
 SECTION_ID = "1234"
-ASSIGNMENT_ID = "2345"
+ASSIGNMENT_ID = "2346"
 
 
 @pytest.fixture


### PR DESCRIPTION
This pull request includes the File Tester spike of GitHub Actions support. Includes trivial file tester and canvas changes to trigger builds.

Unfortunately there's no templating system that allows re-using the same job definition in multiple workflows, so far as I can tell. Thus there are two different projects with virtually the same workflow.

If this all looks good, then I'll create a ticket for Schoology & Google Classroom. Since they use the same `build.py` they will be trivial and can be handled in the same ticket. Then a second ticket for removing the TeamCity support, although we would want to wait a few weeks before making the full commitment.